### PR TITLE
Move Device Rest out of holding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This device service provides easy way for 3'rd party applications, such as Point
 
 The current implementation is meant for one-way communication into EdgeX via async readings. If future use cases determine a need for`commanding`, i.e. two-communication, it can be added then.
 
-## Runtime Prerequisite
+## Runtime Prerequisite    
 
 - core-data
   - Mongo or Redis DB


### PR DESCRIPTION
This PR is for collecting feedback for moving the device-rest-go out of holding. Replaces previous PR that was closed due to rebasing issue.

What types of device are supported?
`Devices, that use REST to send information`
What protocol features are supported / likely to be supported in future.
`REST`
What limitations does the existing implementation have.
`Doesn't support commanding, only async readings`
What hardware and software has it been tested against.
`Linux and Windows X86`
What release of EdgeX is this intended for?
`Fuji 1.1.0`